### PR TITLE
fix: cannot get correct decorator name in windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "typescript-transformer-remove-decorator",
+  "name": "typescript-remove-decorators-transformer",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "typescript-transformer-remove-decorator",
+      "name": "typescript-remove-decorators-transformer",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.11",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "@types/jest": "^29.5.11",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,12 @@ const removeDecorators = (decorators: string[]): ts.TransformerFactory<ts.Source
             }
             if (ts.isDecorator(node)) {
                 const decorator = node as ts.Decorator;
-                const identifier = decorator.getChildAt(1) as ts.Identifier;
-                const decoratorName = identifier.getText();
+                let identifier = decorator.getChildAt(1);
+                // Unexpected behavior (in windows am not sure yet). identifer supposed to be a Identifier but it is a CallExpression
+                if (ts.isCallExpression(identifier)) {
+                    identifier = identifier.expression as ts.Identifier;
+                }
+                let decoratorName = identifier.getText();
                 if (decorators.includes(decoratorName)) {
                     return undefined;
                 }


### PR DESCRIPTION
- The issue is when the identifier is not an `Identifier`. It's a `CallExpression`.
- Check if it's a `CallExpression`, get `.expression` as `Identifier`